### PR TITLE
:lipstick: (component/#9): 메인 페이지 퍼블리싱

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,45 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import styled from '@emotion/styled';
+import Logo from './components/Logo';
+import Button from './components/Button';
 
-function App() {
-  const [count, setCount] = useState(0)
-
+const App = () => {
+  const clickHandler = () => console.log('뽑기');
   return (
     <>
-      <div>
-        <a href="https://vitejs.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      <MainStyled>
+        <MainContentStyled>
+          <h1>Candy Luck</h1>
+          <Logo />
+          <Button clickHandler={clickHandler}>뽑기</Button>
+        </MainContentStyled>
+      </MainStyled>
     </>
-  )
-}
+  );
+};
 
-export default App
+export default App;
+
+const MainStyled = styled.main`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--ivory);
+`;
+
+const MainContentStyled = styled.section`
+  width: 390px;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 80px;
+  background-color: var(--red);
+  h1 {
+    font-family: var(--title);
+    font-size: 40px;
+    color: var(--ivory);
+  }
+`;


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |
| :-------------: |
| <img src='https://github.com/ryukyung/candy-luck/assets/91606951/56ad90c9-60f0-4b43-9155-b2777740e93e' />  |


### 📝 Details

- PC, 태블릿, 모바일 모두 390px로 메인 페이지 사이즈 고정
 
### 💬 Thinking

1. 메인 페이지에서 배경에 뽑기공이 떨어지거나 움직이는 등 애니메이션이 들어가는건 어떤가?
2. 기기 사이즈별로 작은 사이즈에는 작은 로고, 큰 사이즈에는 큰 로고를 넣는건 어떤가?
3. 제목 텍스트의 테두리를 점선으로 만들 수 있다면 바느질한 것처럼 보이게 하는건 어떤가?